### PR TITLE
Fixed build crashing, and added multi-project support

### DIFF
--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFGBuilderImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFGBuilderImpl.groovy
@@ -1,11 +1,21 @@
 /*
- * Minecraft Dev for IntelliJ
+ * Minecraft Development for IntelliJ
  *
- * https://minecraftdev.org
+ * https://mcdev.io/
  *
- * Copyright (c) 2023 minecraft-dev
+ * Copyright (C) 2023 minecraft-dev
  *
- * MIT License
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.demonwav.mcdev.platform.mcp.gradle.tooling

--- a/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFGImpl.groovy
+++ b/src/gradle-tooling-extension/groovy/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFGImpl.groovy
@@ -1,11 +1,21 @@
 /*
- * Minecraft Dev for IntelliJ
+ * Minecraft Development for IntelliJ
  *
- * https://minecraftdev.org
+ * https://mcdev.io/
  *
- * Copyright (c) 2023 minecraft-dev
+ * Copyright (C) 2023 minecraft-dev
  *
- * MIT License
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.demonwav.mcdev.platform.mcp.gradle.tooling

--- a/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFG.java
+++ b/src/gradle-tooling-extension/java/com/demonwav/mcdev/platform/mcp/gradle/tooling/McpModelRFG.java
@@ -1,11 +1,21 @@
 /*
- * Minecraft Dev for IntelliJ
+ * Minecraft Development for IntelliJ
  *
- * https://minecraftdev.org
+ * https://mcdev.io/
  *
- * Copyright (c) 2023 minecraft-dev
+ * Copyright (C) 2023 minecraft-dev
  *
- * MIT License
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.demonwav.mcdev.platform.mcp.gradle.tooling;

--- a/src/main/kotlin/platform/mcp/gradle/McpProjectResolverExtension.kt
+++ b/src/main/kotlin/platform/mcp/gradle/McpProjectResolverExtension.kt
@@ -64,7 +64,7 @@ class McpProjectResolverExtension : AbstractProjectResolverExtension() {
     }
 
     private fun findAllTaskNames(node: DataNode<*>): List<String> {
-        fun findAllTaskNames(node: DataNode<*>, taskNames: MutableList<String>) {
+        fun findAllTaskNames(node: DataNode<*>, taskNames: MutableSet<String>) {
             val data = node.data
             if (data is McpModelData) {
                 data.taskName?.let { taskName ->
@@ -76,9 +76,9 @@ class McpProjectResolverExtension : AbstractProjectResolverExtension() {
             }
         }
 
-        val res = arrayListOf<String>()
+        val res = hashSetOf<String>()
         findAllTaskNames(node, res)
-        return res
+        return res.toList()
     }
 
     override fun populateModuleExtraModels(gradleModule: IdeaModule, ideModule: DataNode<ModuleData>) {

--- a/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
+++ b/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
@@ -1,11 +1,21 @@
 /*
- * Minecraft Dev for IntelliJ
+ * Minecraft Development for IntelliJ
  *
- * https://minecraftdev.org
+ * https://mcdev.io/
  *
- * Copyright (c) 2023 minecraft-dev
+ * Copyright (C) 2023 minecraft-dev
  *
- * MIT License
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 package com.demonwav.mcdev.platform.mcp.gradle.datahandler

--- a/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
+++ b/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
@@ -47,10 +47,15 @@ object McpModelRFGHandler : McpModelDataHandler {
             data.minecraftVersion
         )
 
+        var task = node.data.id;
+        if (!task.endsWith(":")) task += ":"
+
+        task += "generateForgeSrgMappings"
+
         val modelData = McpModelData(
             node.data,
             state,
-            "generateForgeSrgMappings",
+            task,
             data.accessTransformers
         )
 
@@ -64,7 +69,7 @@ object McpModelRFGHandler : McpModelDataHandler {
                     data.mappingFiles.find { it.endsWith("mcp-srg.srg") },
                     SrgType.SRG
                 ),
-                "generateForgeSrgMappings",
+                task,
                 data.accessTransformers
             )
         )

--- a/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
+++ b/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
@@ -48,7 +48,7 @@ object McpModelRFGHandler : McpModelDataHandler {
         )
 
         // This check is based purely on observation
-        var task = node.data.id;
+        var task = node.data.id
         if (!task.startsWith(":")) { // MC project is root
             task = ":"
         } else if (!task.endsWith(":")) { // MC project is not the root

--- a/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
+++ b/src/main/kotlin/platform/mcp/gradle/datahandler/McpModelRFGHandler.kt
@@ -47,8 +47,13 @@ object McpModelRFGHandler : McpModelDataHandler {
             data.minecraftVersion
         )
 
+        // This check is based purely on observation
         var task = node.data.id;
-        if (!task.endsWith(":")) task += ":"
+        if (!task.startsWith(":")) { // MC project is root
+            task = ":"
+        } else if (!task.endsWith(":")) { // MC project is not the root
+            task += ":"
+        }
 
         task += "generateForgeSrgMappings"
 


### PR DESCRIPTION
Small hotfix that makes the license verifier happy again, and also adds compat with nested projects (`includeBuild(...)`)